### PR TITLE
fix: disable stacking of show/hide of the empty state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shiny.emptystate
 Title: Empty State Components For Shiny
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R:
     person(given = "Ryszard",
            family = "Szymański",

--- a/R/empty_state.R
+++ b/R/empty_state.R
@@ -27,6 +27,7 @@ EmptyStateManager <- R6Class( #nolint: object_name_linter
       private$.html_content <- private$process_html(html_content)
       private$.color <- color
     },
+    #' Current visibility state of the empty state UI
     empty_state_shown = FALSE,
     #' Show empty state
     show = function() {

--- a/R/empty_state.R
+++ b/R/empty_state.R
@@ -16,7 +16,7 @@ use_empty_state <- function() {
 #' @importFrom R6 R6Class
 #'
 #' @export
-EmptyStateManager <- R6Class( #nolint: object_name_linter
+EmptyStateManager <- R6Class( # nolint: object_name_linter
   classname = "EmptyStateManager",
   public = list(
     #' @param id id
@@ -27,16 +27,18 @@ EmptyStateManager <- R6Class( #nolint: object_name_linter
       private$.html_content <- private$process_html(html_content)
       private$.color <- color
     },
-    #' Current visibility state of the empty state UI
-    empty_state_shown = FALSE,
+    #' Returns the current visibility state of the empty state UI
+    is_empty_state_show = function() {
+      private$empty_state_shown
+    },
     #' Show empty state
     show = function() {
       session <- private$get_session()
 
       message <- private$create_show_message()
 
-      if (!self$empty_state_shown) {
-        self$empty_state_shown <- TRUE
+      if (!private$empty_state_shown) {
+        private$empty_state_shown <- TRUE
         session$sendCustomMessage(
           "showEmptyState",
           message
@@ -50,8 +52,8 @@ EmptyStateManager <- R6Class( #nolint: object_name_linter
 
       message <- private$create_hide_message()
 
-      if (self$empty_state_shown) {
-        self$empty_state_shown <- FALSE
+      if (private$empty_state_shown) {
+        private$empty_state_shown <- FALSE
         session$sendCustomMessage(
           "hideEmptyState",
           message
@@ -63,6 +65,7 @@ EmptyStateManager <- R6Class( #nolint: object_name_linter
     .id = NA,
     .html_content = NA,
     .color = NA,
+    empty_state_shown = FALSE,
     get_session = function() {
       shiny::getDefaultReactiveDomain()
     },

--- a/R/empty_state.R
+++ b/R/empty_state.R
@@ -27,17 +27,20 @@ EmptyStateManager <- R6Class( #nolint: object_name_linter
       private$.html_content <- private$process_html(html_content)
       private$.color <- color
     },
-
+    empty_state_shown = FALSE,
     #' Show empty state
     show = function() {
       session <- private$get_session()
 
       message <- private$create_show_message()
 
-      session$sendCustomMessage(
-        "showEmptyState",
-        message
-      )
+      if (!self$empty_state_shown) {
+        self$empty_state_shown <- TRUE
+        session$sendCustomMessage(
+          "showEmptyState",
+          message
+        )
+      }
     },
 
     #' Hide empty state
@@ -46,10 +49,13 @@ EmptyStateManager <- R6Class( #nolint: object_name_linter
 
       message <- private$create_hide_message()
 
-      session$sendCustomMessage(
-        "hideEmptyState",
-        message
-      )
+      if (self$empty_state_shown) {
+        self$empty_state_shown <- FALSE
+        session$sendCustomMessage(
+          "hideEmptyState",
+          message
+        )
+      }
     }
   ),
   private = list(

--- a/man/EmptyStateManager.Rd
+++ b/man/EmptyStateManager.Rd
@@ -12,6 +12,7 @@ EmptyStateManager class
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-EmptyStateManager-new}{\code{EmptyStateManager$new()}}
+\item \href{#method-EmptyStateManager-is_empty_state_show}{\code{EmptyStateManager$is_empty_state_show()}}
 \item \href{#method-EmptyStateManager-show}{\code{EmptyStateManager$show()}}
 \item \href{#method-EmptyStateManager-hide}{\code{EmptyStateManager$hide()}}
 \item \href{#method-EmptyStateManager-clone}{\code{EmptyStateManager$clone()}}
@@ -33,12 +34,21 @@ EmptyStateManager class
 \item{\code{html_content}}{html_content}
 
 \item{\code{color}}{color
-Current visibility state of the empty state UI
+Returns the current visibility state of the empty state UI
 Show empty state
 Hide empty state}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-EmptyStateManager-is_empty_state_show"></a>}}
+\if{latex}{\out{\hypertarget{method-EmptyStateManager-is_empty_state_show}{}}}
+\subsection{Method \code{is_empty_state_show()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{EmptyStateManager$is_empty_state_show()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-EmptyStateManager-show"></a>}}

--- a/man/EmptyStateManager.Rd
+++ b/man/EmptyStateManager.Rd
@@ -33,6 +33,7 @@ EmptyStateManager class
 \item{\code{html_content}}{html_content}
 
 \item{\code{color}}{color
+Current visibility state of the empty state UI
 Show empty state
 Hide empty state}
 }


### PR DESCRIPTION
Issue #15 

## Changes description

1. Adds a ~~public variable~~ private variable (`empty_state_shown`) to track the visibility state of the empty state UI
2. `empty_state_shown` can be accessed using the method `is_empty_state_show()`
3. The `show()` and `hide()` methods check the current visibility state and act accordingly. i.e `show()` will act only when the UI is hidden and `hide()` will act only when the UI is shown.
