### PR TITLE
Doc: Adds link to demo; clarifies Rhino

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ server <- function(input, output, session) {
 shinyApp(ui, server)
 ```
 
+For more examples of empty state components, please see this [demo](https://connect.appsilon.com/shiny-emptysate-demo/).
 
 ## How to contribute?
 

--- a/vignettes/use-undraw-drawkit-image.Rmd
+++ b/vignettes/use-undraw-drawkit-image.Rmd
@@ -34,14 +34,17 @@ empty_state <- empty_state_component(
   title = "No content to display"
   )
 ```
-For a [Rhino](https://appsilon.github.io/rhino/index.html) application, we suggest storing images in a directory within `app/static`. 
+For a [Rhino](https://appsilon.github.io/rhino/index.html) application, we suggest storing images in a directory within `app/static`. Rhino encourages the use of Shiny modules, so when creating an empty state manager always namespace the id of the element you want to handle.
 
 If the image is in `app/static/img/image.png`, you can use the same code as above.
 Update the `src` path accordingly.
 
 ```r
+# In your module's server function
+ns <- session$ns
+
 empty_state_manager <- EmptyStateManager$new(
-    id = "myElement",
+    id = ns("myElement"),
     html_content = tags$image(src = "app/static/img/image.png")
   )
   


### PR DESCRIPTION
## Changes description

* Adds demo link in README
* Adds note on properly namespacing element when using with Rhino and Shiny modules
