### PR TITLE
chore: Fix title in the DESCRIPTION.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: shiny.emptystate
-Title: Empty State Components For Shiny
+Title: Empty State Components for Shiny
 Version: 0.0.0.9002
 Authors@R:
     person("Ryszard", "Szymański", , "ryszard@appsilon.com", role = c("aut", "cre"))


### PR DESCRIPTION
R-hub builder output:
```
The Title field should be in title case. Current version is:
‘Empty State Components For Shiny’
In title case that is:
‘Empty State Components for Shiny’
```
