### PR TITLE
chore: Resolve CRAN comments.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,8 +30,6 @@ Suggests:
     spelling,
     testthat (>= 3.0.0),
     withr
-VignetteBuilder:
-    knitr
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,6 +9,5 @@
 library(testthat)
 library(shiny.emptystate)
 library(shinytest2)
-use_shinytest2()
 
 test_check("shiny.emptystate")

--- a/tests/testthat/setup-shinytest2.R
+++ b/tests/testthat/setup-shinytest2.R
@@ -1,2 +1,0 @@
-# Load application support files into testing environment
-shinytest2::load_app_env()

--- a/tests/testthat/test-empty_state.R
+++ b/tests/testthat/test-empty_state.R
@@ -32,6 +32,7 @@ describe("EmptyStateManager", {
   })
 
   it("checks the empty state component is visible when triggered", {
+    skip_on_cran()
     expected_div <-
       "<div class=\"empty-state-content\"><div class=\"myDiv\"></div></div>"
     app <- shinytest2::AppDriver$new(test_app(), name = "test")
@@ -44,12 +45,14 @@ describe("EmptyStateManager", {
   })
 
   it("checks the empty state component is hidden when not triggered", {
+    skip_on_cran()
     app <- shinytest2::AppDriver$new(test_app(), name = "test")
     expect_null(app$get_html(selector = ".empty-state-content"))
     app$stop()
   })
 
   it("checks the empty state component is hidden when triggered", {
+    skip_on_cran()
     app <- shinytest2::AppDriver$new(test_app(), name = "test")
     app$click("show")
     app$click("hide")


### PR DESCRIPTION
- disable `shinytest2` tests on CRAN (not able to work due to the lack of Chrome)
- remove redundant parts of `shinytest2` setup
- remove redundant `VignetteBuilder` from the DESCRIPTION
